### PR TITLE
Add Lenis smooth scrolling

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,6 +13,12 @@
     <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'%3E%3Cpath fill='%23ef4444' d='M5 40c10 0 12-16 24-16s14 16 30 16v8c-16 0-18-16-30-16S19 48 5 48z'/%3E%3C/svg%3E" />
     <link rel="preload" href="styles.css" as="style" />
     <link rel="stylesheet" href="styles.css" />
+    <script
+      defer
+      src="https://unpkg.com/@studio-freight/lenis@1.0.6/dist/lenis.min.js"
+      integrity="sha384-6JJm0dQiSMIs5asq+8Zz9Ur0Ik/gv7VySKKJEErd3fxEw9//2m77WlcZ4Fv0a1nb"
+      crossorigin="anonymous"
+    ></script>
     <script defer src="script.js"></script>
   </head>
   <body>

--- a/script.js
+++ b/script.js
@@ -1,5 +1,21 @@
 // Utilidades simples para UX da landing
 (function () {
+  const lenis = window.Lenis
+    ? new window.Lenis({
+        duration: 1.1,
+        smoothWheel: true,
+        smoothTouch: false,
+      })
+    : null;
+
+  if (lenis) {
+    const raf = (time) => {
+      lenis.raf(time);
+      requestAnimationFrame(raf);
+    };
+    requestAnimationFrame(raf);
+  }
+
   const header = document.querySelector('.site-header');
   const toTop = document.querySelector('.to-top');
   const year = document.getElementById('year');
@@ -23,7 +39,11 @@
     const el = document.querySelector(id);
     if (!el) return;
     e.preventDefault();
-    el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    if (lenis) {
+      lenis.scrollTo(el, { lock: true });
+    } else {
+      el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    }
     history.pushState(null, '', id);
   });
 


### PR DESCRIPTION
## Summary
- load Lenis from CDN to enable smooth scrolling animations across the landing page
- initialize Lenis and integrate it with existing anchor navigation behavior for graceful fallback

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dfcef129f083298e0534bd399d3c29