### PR TITLE
Add mobile close control for product modal

### DIFF
--- a/index.html
+++ b/index.html
@@ -316,6 +316,13 @@
               <ul class="product-modal__features" data-product-features></ul>
               <div class="product-modal__actions">
                 <button class="btn btn-primary" type="button" data-product-action></button>
+                <button
+                  class="btn btn-ghost product-modal__close-mobile"
+                  type="button"
+                  data-product-close
+                >
+                  Fechar
+                </button>
                 <small class="product-modal__note">Envio em até 24h para capitais selecionadas.</small>
               </div>
             </div>

--- a/script.js
+++ b/script.js
@@ -195,7 +195,10 @@
     const prevBtn = modal.querySelector('[data-slider-prev]');
     const nextBtn = modal.querySelector('[data-slider-next]');
     const statusEl = modal.querySelector('[data-slider-status]');
-    const closeBtn = modal.querySelector('[data-product-close]');
+    const closeButtons = Array.from(
+      modal.querySelectorAll('[data-product-close]')
+    );
+    const closeBtn = closeButtons[0] || null;
     const overlay = modal.querySelector('[data-product-overlay]');
 
     let sliderItems = [];
@@ -344,8 +347,10 @@
       goToSlide(idx);
     });
 
-    closeBtn?.addEventListener('click', () =>
-      closeModal({ returnFocus: true, replaceHistory: true })
+    closeButtons.forEach((button) =>
+      button.addEventListener('click', () =>
+        closeModal({ returnFocus: true, replaceHistory: true })
+      )
     );
     overlay?.addEventListener('click', () =>
       closeModal({ returnFocus: false, replaceHistory: true })

--- a/styles.css
+++ b/styles.css
@@ -403,6 +403,10 @@ body.modal-open { overflow: hidden; }
   align-content: start;
 }
 
+.product-modal__close-mobile {
+  display: none;
+}
+
 .product-modal__note {
   color: var(--muted);
 }
@@ -438,6 +442,11 @@ body.modal-open { overflow: hidden; }
   .product-modal__close {
     top: calc(0.75rem + env(safe-area-inset-top, 0));
     right: calc(0.75rem + env(safe-area-inset-right, 0));
+  }
+
+  .product-modal__close-mobile {
+    display: inline-flex;
+    width: 100%;
   }
 
   .product-slider__control {


### PR DESCRIPTION
## Summary
- add a dedicated close button within the product modal actions for small screens
- update modal script and styles so multiple close controls are supported and mobile layout displays the button full width

## Testing
- Manual - Verified the modal close button appears on mobile viewport

------
https://chatgpt.com/codex/tasks/task_e_68dff94a53c88329ba8e23a9d4fa58bf